### PR TITLE
Close 'coords_file' after writing to it

### DIFF
--- a/target.py
+++ b/target.py
@@ -104,6 +104,7 @@ class Target(object):
         basename = "standards"
         fd, coords_file = tempfile.mkstemp(prefix=basename, suffix=".coords")
         os.write(fd, "{0} {1} \n".format(self.RA, self.DEC))
+        os.close(fd)
 
         if self.objtype == "standard":
             iraf.noao(_doprint=0)


### PR DESCRIPTION
The file must be explicitly closed — otherwise, the coordinates may not be written to disk!
